### PR TITLE
Fixed 1wire messages

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -139,6 +139,12 @@ class evok extends client {
 
     parse(message) {
         // handle devices
+
+        //1wire messages are not in an array, so make it an array
+        if (!Array.isArray(message)) {
+            message = [message]
+        }
+
         message.forEach((device) => {
             let previous = this.device(device.dev, device.circuit)
 


### PR DESCRIPTION
UniPi sends the 1wire data as a single hash and not as a array of hashes.
Now these are converted to an array. It makes it possible to
process these messages the same way as all the others.